### PR TITLE
[TH2-3739]: GRPCProvider5API uses proto file for RDP v6 instead of v5

### DIFF
--- a/th2_data_services/provider/v5/commands/grpc.py
+++ b/th2_data_services/provider/v5/commands/grpc.py
@@ -427,6 +427,7 @@ class GetMessagesGRPCObject(IGRPCProvider5Command, ProviderAdaptableCommand):
         result_count_limit: int = None,
         keep_open: bool = False,
         filters: List[Filter] = None,
+        message_id: List[str] = None,
     ):
         """GetMessagesGRPCObject constructor.
 
@@ -439,6 +440,7 @@ class GetMessagesGRPCObject(IGRPCProvider5Command, ProviderAdaptableCommand):
             result_count_limit: Result count limit.
             keep_open: If the search has reached the current moment.
                 It is need to wait further for the appearance of new data.
+            message_id: List of message ids to restore the search
             filters: Filters using in search for messages.
 
         """
@@ -451,6 +453,7 @@ class GetMessagesGRPCObject(IGRPCProvider5Command, ProviderAdaptableCommand):
         self._result_count_limit = result_count_limit
         self._keep_open = keep_open
         self._filters = filters
+        self._message_id = message_id
 
     def handle(self, data_source: GRPCProvider5DataSource) -> List[MessageData]:
         api = data_source.source_api
@@ -467,6 +470,7 @@ class GetMessagesGRPCObject(IGRPCProvider5Command, ProviderAdaptableCommand):
             result_count_limit=self._result_count_limit,
             keep_open=self._keep_open,
             filters=self._filters,
+            message_id=self._message_id,
         )
         for response in stream_response:
             if response.WhichOneof("data") == "message":
@@ -493,6 +497,7 @@ class GetMessages(IGRPCProvider5Command, ProviderAdaptableCommand):
         result_count_limit: int = None,
         keep_open: bool = False,
         filters: List[Filter] = None,
+        message_id: List[str] = None,
         cache: bool = False,
     ):
         """GetMessages constructor.
@@ -507,6 +512,7 @@ class GetMessages(IGRPCProvider5Command, ProviderAdaptableCommand):
             keep_open: If the search has reached the current moment.
                 It is need to wait further for the appearance of new data.
             filters: Filters using in search for messages.
+            message_id: List of message ids to restore the search
             cache: If True, all requested data from rpt-data-provider will be saved to cache.
 
         """
@@ -519,6 +525,7 @@ class GetMessages(IGRPCProvider5Command, ProviderAdaptableCommand):
         self._result_count_limit = result_count_limit
         self._keep_open = keep_open
         self._filters = filters
+        self._message_id = message_id
         self._cache = cache
 
         self._decoder = GRPCObjectToDictAdapter()

--- a/th2_data_services/provider/v5/provider_api/grpc.py
+++ b/th2_data_services/provider/v5/provider_api/grpc.py
@@ -152,6 +152,7 @@ class GRPCProvider5API(IGRPCProviderSourceAPI):
         result_count_limit: int = None,
         keep_open: bool = False,
         filters: Optional[List[Filter]] = None,
+        message_id: Optional[List[str]] = None,
     ) -> Iterable[StreamResponse]:
         """GRPC-API `searchMessages` call creates a message stream that matches the filter.
 
@@ -167,12 +168,14 @@ class GRPCProvider5API(IGRPCProviderSourceAPI):
             keep_open: Option if the search has reached the current moment,
                 it is necessary to wait further for the appearance of new data.
             filters: Which filters to apply in a search.
+            message_id: List of message ids to restore the search
 
         Returns:
             Iterable object which return messages as parts of streaming response.
         """
         if stream is None:
             raise TypeError("Argument 'stream' is required.")
+        message_id = message_id or []
         self.__search_basic_checks(
             start_timestamp=start_timestamp,
             end_timestamp=end_timestamp,
@@ -190,7 +193,7 @@ class GRPCProvider5API(IGRPCProviderSourceAPI):
             filters=filters,
         )
         resume_from_id = self.__build_message_id_object(resume_from_id) if resume_from_id else None
-
+        message_id = [self.__build_message_id_object(id_) for id_ in message_id]
         message_search_request = MessageSearchRequest(
             start_timestamp=basic_request.start_timestamp,
             end_timestamp=basic_request.end_timestamp,
@@ -200,6 +203,7 @@ class GRPCProvider5API(IGRPCProviderSourceAPI):
             result_count_limit=basic_request.result_count_limit,
             keep_open=basic_request.keep_open,
             filters=basic_request.filters,
+            message_id=message_id,
         )
         return self.__stub.searchMessages(message_search_request)
 


### PR DESCRIPTION
Partial fix (only for grpc messages search api)