### PR TITLE
[TH2-4222] add integration tests

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -7,7 +7,7 @@ jobs:
   test:
     strategy:
       matrix:
-        providers: [rdp, rdp5, rdp6, lwdp, lwdp1]
+        providers: [ rdp, rdp5, rdp6, lwdp, lwdp1 ]
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -5,6 +5,9 @@ on:
 
 jobs:
   test:
+    strategy:
+      matrix:
+        providers: [rdp, rdp5, rdp6, lwdp, lwdp1]
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
@@ -24,8 +27,4 @@ jobs:
           python unittestV6.py
       - name: Install dependencies
         run: |
-          pip install th2-data-services[rdp]
-          pip install th2-data-services[rdp5]
-          pip install th2-data-services[rdp6]
-          pip install th2-data-services[lwdp]
-          pip install th2-data-services[lwdp1]
+          pip install th2-data-services[${{ matrix.providers }}]

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: 3.7
-      - name: Install dependencies
+      - name: Install requirements
         run: |
           pip install -r requirements.txt
           pip install importlib importlib-metadata
@@ -22,3 +22,10 @@ jobs:
           cd tests
           python unittestV5.py
           python unittestV6.py
+      - name: Install dependencies
+        run: |
+          pip install th2-data-services[rdp]
+          pip install th2-data-services[rdp5]
+          pip install th2-data-services[rdp6]
+          pip install th2-data-services[lwdp]
+          pip install th2-data-services[lwdp1]


### PR DESCRIPTION
Chaged `Install dependencies` to `Install requirements` because it best describes the action (`pip install -r requirements.txt`)