### PR TITLE
Data loss fixed

### DIFF
--- a/documentation/api/provider.v5.commands.http.md
+++ b/documentation/api/provider.v5.commands.http.md
@@ -341,7 +341,7 @@ handle(data_source: HTTPProvider5DataSource) → Data
 
 ---
 
-<a href="../../th2_data_services/provider/v5/commands/http.py#L365"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../th2_data_services/provider/v5/commands/http.py#L368"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `GetMessageById`
 A Class-Command for request to rpt-data-provider. 
@@ -362,7 +362,7 @@ Please note, Provider5 doesn't return `attachedEventIds`. It will be == []. It's
  
  - <b>`MessageNotFound`</b>:  If message by id wasn't found. 
 
-<a href="../../th2_data_services/provider/v5/commands/http.py#L380"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../th2_data_services/provider/v5/commands/http.py#L383"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `__init__`
 
@@ -384,7 +384,7 @@ GetMessageById constructor.
 
 ---
 
-<a href="../../th2_data_services/provider/v5/commands/http.py#L391"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../th2_data_services/provider/v5/commands/http.py#L394"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `handle`
 
@@ -399,7 +399,7 @@ handle(data_source: HTTPProvider5DataSource) → dict
 
 ---
 
-<a href="../../th2_data_services/provider/v5/commands/http.py#L409"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../th2_data_services/provider/v5/commands/http.py#L412"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `GetMessagesById`
 A Class-Command for request to rpt-data-provider. 
@@ -420,7 +420,7 @@ Please note, Provider5 doesn't return `attachedEventIds`. It will be == []. It's
  
  - <b>`MessageNotFound`</b>:  If any message by id wasn't found. 
 
-<a href="../../th2_data_services/provider/v5/commands/http.py#L424"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../th2_data_services/provider/v5/commands/http.py#L427"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `__init__`
 
@@ -442,7 +442,7 @@ GetMessagesById constructor.
 
 ---
 
-<a href="../../th2_data_services/provider/v5/commands/http.py#L435"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../th2_data_services/provider/v5/commands/http.py#L438"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `handle`
 
@@ -457,7 +457,7 @@ handle(data_source: HTTPProvider5DataSource) → List[dict]
 
 ---
 
-<a href="../../th2_data_services/provider/v5/commands/http.py#L452"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../th2_data_services/provider/v5/commands/http.py#L455"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `GetMessagesSSEBytes`
 A Class-Command for request to rpt-data-provider. 
@@ -470,7 +470,7 @@ It searches messages stream by options.
  
  - <b>`Iterable[dict]`</b>:  Stream of Th2 messages. 
 
-<a href="../../th2_data_services/provider/v5/commands/http.py#L461"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../th2_data_services/provider/v5/commands/http.py#L464"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `__init__`
 
@@ -513,7 +513,7 @@ GetMessagesSSEBytes constructor.
 
 ---
 
-<a href="../../th2_data_services/provider/v5/commands/http.py#L510"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../th2_data_services/provider/v5/commands/http.py#L513"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `handle`
 
@@ -530,7 +530,7 @@ handle(
 
 ---
 
-<a href="../../th2_data_services/provider/v5/commands/http.py#L544"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../th2_data_services/provider/v5/commands/http.py#L547"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `GetMessagesSSEEvents`
 A Class-Command for request to rpt-data-provider. 
@@ -543,7 +543,7 @@ It searches messages stream by options.
  
  - <b>`Iterable[dict]`</b>:  Stream of Th2 messages. 
 
-<a href="../../th2_data_services/provider/v5/commands/http.py#L553"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../th2_data_services/provider/v5/commands/http.py#L556"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `__init__`
 
@@ -590,7 +590,7 @@ GetMessagesSSEEvents constructor.
 
 ---
 
-<a href="../../th2_data_services/provider/v5/commands/http.py#L604"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../th2_data_services/provider/v5/commands/http.py#L607"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `handle`
 
@@ -607,7 +607,7 @@ handle(
 
 ---
 
-<a href="../../th2_data_services/provider/v5/commands/http.py#L630"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../th2_data_services/provider/v5/commands/http.py#L633"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `GetMessages`
 A Class-Command for request to rpt-data-provider. 
@@ -620,7 +620,7 @@ It searches messages stream by options.
  
  - <b>`Iterable[dict]`</b>:  Stream of Th2 messages. 
 
-<a href="../../th2_data_services/provider/v5/commands/http.py#L639"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../th2_data_services/provider/v5/commands/http.py#L642"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `__init__`
 
@@ -671,7 +671,7 @@ GetMessages constructor.
 
 ---
 
-<a href="../../th2_data_services/provider/v5/commands/http.py#L696"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../th2_data_services/provider/v5/commands/http.py#L699"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `handle`
 

--- a/tests/tests_unit/test_data/test_data.py
+++ b/tests/tests_unit/test_data/test_data.py
@@ -300,13 +300,28 @@ def test_sift_skip_data(general_data: List[dict]):
     assert output1 != output2
 
 
-def test_data_loss(general_data: List[dict]):
-    # Iterating over and over object doesn't lose any data
-    data = Data(general_data)
-    general_data_len = len(general_data)
-    assert data.len == general_data_len
-    assert data.len == general_data_len
-    assert data.len == general_data_len
+def test_data_loss_with_fixed_generator(general_data: List[dict]):
+    def general_data_gen():
+        return (item for item in general_data)
+
+    data = Data(general_data_gen())
+    for _ in range(3):
+        for _ in data:
+            pass
+
+    assert len(list(data)) == 0
+
+
+def test_data_loss_with_new_generator(general_data: List[dict]):
+    def general_data_gen():
+        return (item for item in general_data)
+
+    data = Data(general_data_gen)
+    for _ in range(3):
+        for _ in data:
+            pass
+
+    assert len(list(data)) == len(general_data)
 
 
 def test_big_modification_chain(log_checker):

--- a/tests/tests_unit/test_data/test_data.py
+++ b/tests/tests_unit/test_data/test_data.py
@@ -303,9 +303,10 @@ def test_sift_skip_data(general_data: List[dict]):
 def test_data_loss(general_data: List[dict]):
     # Iterating over and over object doesn't lose any data
     data = Data(general_data)
-    assert data.len == 21
-    assert data.len == 21
-    assert data.len == 21
+    general_data_len = len(general_data)
+    assert data.len == general_data_len
+    assert data.len == general_data_len
+    assert data.len == general_data_len
 
 
 def test_big_modification_chain(log_checker):

--- a/tests/tests_unit/test_data/test_data.py
+++ b/tests/tests_unit/test_data/test_data.py
@@ -300,6 +300,14 @@ def test_sift_skip_data(general_data: List[dict]):
     assert output1 != output2
 
 
+def test_data_loss(general_data: List[dict]):
+    # Iterating over and over object doesn't lose any data
+    data = Data(general_data)
+    assert data.len == 21
+    assert data.len == 21
+    assert data.len == 21
+
+
 def test_big_modification_chain(log_checker):
     d1 = Data([1, 2, 3, 4, 5]).use_cache(True)
     d2 = d1.filter(lambda x: x == 1 or x == 2)

--- a/th2_data_services/provider/v5/commands/http.py
+++ b/th2_data_services/provider/v5/commands/http.py
@@ -341,8 +341,11 @@ class GetEvents(IHTTPProvider5Command, ProviderAdaptableCommand):
 
     def handle(self, data_source: HTTPProvider5DataSource) -> Data:  # noqa: D102
         source = partial(self.sse_handler.handle, partial(self.__handle_stream, data_source))
-        source = [self._handle_adapters(record) for record in source() if record is not None]
-        return Data(source).use_cache(self._cache)
+
+        def src():
+            return (self._handle_adapters(record) for record in source() if record is not None)
+
+        return Data(src).use_cache(self._cache)
 
     def __handle_stream(self, data_source: HTTPProvider5DataSource) -> Generator[dict, None, None]:
         stream = GetEventsSSEEvents(
@@ -695,8 +698,11 @@ class GetMessages(IHTTPProvider5Command, ProviderAdaptableCommand):
 
     def handle(self, data_source: HTTPProvider5DataSource) -> Data:  # noqa: D102
         source = partial(self.sse_handler.handle, partial(self.__handle_stream, data_source))
-        source = [self._handle_adapters(record) for record in source() if record is not None]
-        return Data(source).use_cache(self._cache)
+
+        def src():
+            return (self._handle_adapters(record) for record in source() if record is not None)
+
+        return Data(src).use_cache(self._cache)
 
     def __handle_stream(self, data_source: HTTPProvider5DataSource) -> Generator[dict, None, None]:
         stream = GetMessagesSSEEvents(

--- a/th2_data_services/provider/v5/commands/http.py
+++ b/th2_data_services/provider/v5/commands/http.py
@@ -341,7 +341,7 @@ class GetEvents(IHTTPProvider5Command, ProviderAdaptableCommand):
 
     def handle(self, data_source: HTTPProvider5DataSource) -> Data:  # noqa: D102
         source = partial(self.sse_handler.handle, partial(self.__handle_stream, data_source))
-        source = (self._handle_adapters(record) for record in source() if record is not None)
+        source = [self._handle_adapters(record) for record in source() if record is not None]
         return Data(source).use_cache(self._cache)
 
     def __handle_stream(self, data_source: HTTPProvider5DataSource) -> Generator[dict, None, None]:
@@ -695,7 +695,7 @@ class GetMessages(IHTTPProvider5Command, ProviderAdaptableCommand):
 
     def handle(self, data_source: HTTPProvider5DataSource) -> Data:  # noqa: D102
         source = partial(self.sse_handler.handle, partial(self.__handle_stream, data_source))
-        source = (self._handle_adapters(record) for record in source() if record is not None)
+        source = [self._handle_adapters(record) for record in source() if record is not None]
         return Data(source).use_cache(self._cache)
 
     def __handle_stream(self, data_source: HTTPProvider5DataSource) -> Generator[dict, None, None]:

--- a/th2_data_services/provider/v6/commands/http.py
+++ b/th2_data_services/provider/v6/commands/http.py
@@ -30,6 +30,7 @@ from th2_data_services.sse_client import SSEClient
 from th2_data_services.provider.adapters.adapter_sse import get_default_sse_adapter
 from th2_data_services.decode_error_handler import UNICODE_REPLACE_HANDLER
 
+
 # LOG import logging
 
 # LOG logger = logging.getLogger(__name__)
@@ -331,8 +332,11 @@ class GetEvents(IHTTPProvider6Command, ProviderAdaptableCommand):
 
     def handle(self, data_source: HTTPProvider6DataSource) -> Data:  # noqa: D102
         source = partial(self.sse_handler.handle, partial(self.__handle_stream, data_source))
-        source = [self._handle_adapters(record) for record in source() if record is not None]
-        return Data(source).use_cache(self._cache)
+
+        def src():
+            return (self._handle_adapters(record) for record in source() if record is not None)
+
+        return Data(src).use_cache(self._cache)
 
     def __handle_stream(self, data_source: HTTPProvider6DataSource) -> Generator[dict, None, None]:
         stream = GetEventsSSEEvents(
@@ -699,8 +703,11 @@ class GetMessages(IHTTPProvider6Command, ProviderAdaptableCommand):
 
     def handle(self, data_source: HTTPProvider6DataSource) -> Data:  # noqa: D102
         source = partial(self.sse_handler.handle, partial(self.__handle_stream, data_source))
-        source = [self._handle_adapters(record) for record in source() if record is not None]
-        return Data(source).use_cache(self._cache)
+
+        def src():
+            return (self._handle_adapters(record) for record in source() if record is not None)
+
+        return Data(src).use_cache(self._cache)
 
     def __handle_stream(self, data_source: HTTPProvider6DataSource) -> Generator[dict, None, None]:
         stream = GetMessagesSSEEvents(

--- a/th2_data_services/provider/v6/commands/http.py
+++ b/th2_data_services/provider/v6/commands/http.py
@@ -331,7 +331,7 @@ class GetEvents(IHTTPProvider6Command, ProviderAdaptableCommand):
 
     def handle(self, data_source: HTTPProvider6DataSource) -> Data:  # noqa: D102
         source = partial(self.sse_handler.handle, partial(self.__handle_stream, data_source))
-        source = (self._handle_adapters(record) for record in source() if record is not None)
+        source = [self._handle_adapters(record) for record in source() if record is not None]
         return Data(source).use_cache(self._cache)
 
     def __handle_stream(self, data_source: HTTPProvider6DataSource) -> Generator[dict, None, None]:
@@ -699,7 +699,7 @@ class GetMessages(IHTTPProvider6Command, ProviderAdaptableCommand):
 
     def handle(self, data_source: HTTPProvider6DataSource) -> Data:  # noqa: D102
         source = partial(self.sse_handler.handle, partial(self.__handle_stream, data_source))
-        source = (self._handle_adapters(record) for record in source() if record is not None)
+        source = [self._handle_adapters(record) for record in source() if record is not None]
         return Data(source).use_cache(self._cache)
 
     def __handle_stream(self, data_source: HTTPProvider6DataSource) -> Generator[dict, None, None]:


### PR DESCRIPTION
Tried passing generator object to `Data` to preserve memory, but it led to memory loss because once generators are exhausted it no longer holds the data.